### PR TITLE
fixed: bug in tag style

### DIFF
--- a/grammars/argdown.cson
+++ b/grammars/argdown.cson
@@ -167,7 +167,7 @@
   #Tags
   {
     'begin': '#(?:\\([^\\)]+\\)|[\\w-]+)'
-    'end': '[ \\t$]'
+    'end': '[\\s*$]'
     'name': 'markup.tag.argdown'
   }
   #links (gfm.cson)


### PR DESCRIPTION
Fixed a bug that would continue the tag style through the pcs index number in round brackets whenever a tag occurred at the end of a line followed by a pcs index number in round brackets (even when two line breaks separated the tag and the pcs index number in round brackets). For example, in the text "<Argument from expertise>: Scientific studies have established a causal link between violence in film and a similar behaviour in spectators. #pro\r\r(1) Scientific studies have established...", the text "#pro\r\r(1)" was all styled as a tag when only "#pro" should have been styled as a tag. This commit appears to fix the bug.